### PR TITLE
Add session expiration logic

### DIFF
--- a/manitas-creativas-frontend/src/components/Main/index.tsx
+++ b/manitas-creativas-frontend/src/components/Main/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import useSessionExpiration from "../../hooks/useSessionExpiration";
 import "antd/dist/reset.css"; // Import Ant Design styles
 import {
   MenuFoldOutlined,
@@ -18,6 +19,7 @@ import { Link, Outlet } from "react-router-dom";
 const { Header, Sider, Content } = Layout;
 
 const Main: React.FC = () => {
+  useSessionExpiration();
   const [collapsed, setCollapsed] = useState(false);
   const {
     token: { colorBgContainer, borderRadiusLG },

--- a/manitas-creativas-frontend/src/hooks/useSessionExpiration.ts
+++ b/manitas-creativas-frontend/src/hooks/useSessionExpiration.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { isAuthenticated } from '../services/authService';
+import { message } from 'antd';
+
+const SESSION_CHECK_INTERVAL_MS = 60 * 1000; // 1 minute
+
+const useSessionExpiration = (): void => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const checkExpiry = () => {
+      if (!isAuthenticated()) {
+        message.info('Su sesión ha expirado. Por favor, inicie sesión nuevamente.');
+        navigate('/', { replace: true });
+      }
+    };
+
+    checkExpiry();
+    const interval = setInterval(checkExpiry, SESSION_CHECK_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [navigate, location]);
+};
+
+export default useSessionExpiration;

--- a/manitas-creativas-frontend/src/routing/PrivateRoute.tsx
+++ b/manitas-creativas-frontend/src/routing/PrivateRoute.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { isAuthenticated } from '../services/authService';
+import { message } from 'antd';
+
+interface Props {
+  children: JSX.Element;
+}
+
+const PrivateRoute: React.FC<Props> = ({ children }) => {
+  if (!isAuthenticated()) {
+    message.info('Su sesión ha expirado. Por favor, inicie sesión nuevamente.');
+    return <Navigate to="/" replace />;
+  }
+  return children;
+};
+
+export default PrivateRoute;

--- a/manitas-creativas-frontend/src/routing/routes.tsx
+++ b/manitas-creativas-frontend/src/routing/routes.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Route, Routes } from "react-router-dom";
 //import { userStore } from "../store";
-//import PrivateRoute from "./PrivateRoute";
+import PrivateRoute from "./PrivateRoute";
 
 const SignIn = React.lazy(() => import("../components/SignIn"));
 const Main = React.lazy(() => import("../components/Main"));
@@ -22,7 +22,14 @@ const AppRoutes: React.FC = () => {
     <Routes>
       {" "}
       <Route path="/" element={<SignIn />} />
-      <Route path="/main" element={<Main />}>
+      <Route
+        path="/main"
+        element={
+          <PrivateRoute>
+            <Main />
+          </PrivateRoute>
+        }
+      >
         <Route path="tuitions" element={<Tuitions />} />
         <Route path="other-payments" element={<OtherPayments />} />
         <Route path="statement" element={<Statement />} />


### PR DESCRIPTION
## Summary
- handle session expiry in `authService`
- add a `PrivateRoute` component
- guard `/main` route using the new component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68448de137488321a1d86a204c975a21